### PR TITLE
Add frontend validation and set preferredCountry from admin

### DIFF
--- a/Block/PhoneNumber.php
+++ b/Block/PhoneNumber.php
@@ -62,8 +62,11 @@ class PhoneNumber extends Template
         $config  = [
             "nationalMode" => false,
             "utilsScript"  => $this->getViewFileUrl('MaxMage_InternationalTelephoneInput::js/utils.js'),
-            "preferredCountries" => [$this->helper->preferedCountry()]
         ];
+
+        if ($this->helper->preferedCountry()) {
+            $config["preferredCountries"] = [$this->helper->preferedCountry()];
+        }
 
         if ($this->helper->allowedCountries()) {
             $config["onlyCountries"] = explode(",", $this->helper->allowedCountries());

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -21,7 +21,7 @@ class Data extends AbstractHelper
 
     const XML_PATH_INTERNATIONAL_TELEPHONE_MULTISELECT_COUNTRIES_ALLOWED = 'internationaltelephoneinput/general/allow';
 
-    const XML_PATH_PREFERED_COUNTRY = 'general/store_information/country_id';
+    const XML_PATH_PREFERED_COUNTRY = 'internationaltelephoneinput/general/preferedCountry';
 
     /**
      * @return mixed
@@ -64,7 +64,7 @@ class Data extends AbstractHelper
      */
     public function telephoneFieldConfig($addressType, $method = '')
     {
-        return  [
+        return [
             'component' => 'Magento_Ui/js/form/element/abstract',
             'config' => [
                 'customScope' => $addressType . $method,
@@ -82,9 +82,10 @@ class Data extends AbstractHelper
             'provider' => 'checkoutProvider',
             'sortOrder' => 120,
             'validation' => [
-                "required-entry"    => true,
-                "max_text_length"   => 255,
-                "min_text_length"   => 1
+                "required-entry" => true,
+                "max_text_length" => 255,
+                "min_text_length" => 1,
+                'validate-phone-number' => true
             ],
             'options' => [],
             'filterBy' => null,

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -17,6 +17,11 @@
                     <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
                     <can_be_empty>1</can_be_empty>
                 </field>
+                <field id="preferedCountry" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Prefered Country</label>
+                    <source_model>Magento\Directory\Model\Config\Source\Country</source_model>
+                    <can_be_empty>1</can_be_empty>
+                </field>
             </group>
         </section>
     </system>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -12,5 +12,12 @@ var config = {
         'internationalTelephoneInput': {
             'deps':['jquery', 'intlTelInput']
         }
+    },
+    config: {
+        mixins: {
+            'Magento_Ui/js/lib/validation/validator': {
+                'MaxMage_InternationalTelephoneInput/js/phoneValidator': true
+            }
+        }
     }
 };

--- a/view/frontend/web/js/phoneValidator.js
+++ b/view/frontend/web/js/phoneValidator.js
@@ -1,0 +1,42 @@
+define([
+    'jquery',
+    'intlTelInput'
+], function ($, intlTelInput) {
+    'use strict';
+
+    return function (validator) {
+
+        const errorMap = ["Invalid number", "Invalid country code", "Too short", "Too long", "Invalid number"];
+
+        let validatorObj = {
+            message: '',
+            validate: function (value, params, additionalParams) {
+                var countryCode = $(".selected-flag .iti-flag").attr('class');
+
+                if (countryCode === undefined) {
+                    this.message = errorMap[1];
+                    return false;
+                }
+
+                countryCode = countryCode.split(' ')[1];
+
+                var isValid = intlTelInputUtils.isValidNumber(value, countryCode);
+                var errorCode = intlTelInputUtils.getValidationError(value, countryCode);
+
+                if (isValid) {
+                    this.message = errorMap[errorCode];
+                }
+
+                return isValid;
+            },
+        }
+
+        validatorObj.addRule(
+            'validate-phone-number',
+            validatorObj.validate,
+            $.mage.__(validatorObj.message)
+        );
+
+        return validatorObj;
+    };
+});


### PR DESCRIPTION
This PR adds front end validation and the ability to set the preferredCountry from the Magento 2 backend as not all stores have the _general/store_information/country_id_ config value set